### PR TITLE
feat: global.css 색상 텍스트 폰트 등록

### DIFF
--- a/global.css
+++ b/global.css
@@ -1,67 +1,153 @@
+/* 1. Tailwind 기본 모듈 불러오기 */
 @import "tailwindcss";
 @import "tailwindcss";
+/* 2. Tailwind 애니메이션 플러그인 */
 @plugin "tailwindcss-animate";
+/* 3. Pretendard 폰트 (CDN 버전 사용) */
 @import url("https://cdn.jsdelivr.net/gh/orioncactus/pretendard@v1.3.9/dist/web/static/pretendard.min.css");
 
 /* Tailwind v4 design tokens (compatible with shadcn/ui) */
 :root {
-  --background: 0 0% 100%;
-  --foreground: 222.2 84% 4.9%;
+  /* ▶ 메인 컬러 (Primary) */
+  --primary-main:        230 91% 61%;   /*파란색 #3E56F6 */
+  --primary-sub-black:   0 0% 0%;       /*검정 #000000 */
+  --primary-sub-white:   0 0% 100%;     /*흰색 #FFFFFF */
+  --primary-sub-gray-1:  0 0% 85%;      /*밝은 회색 #D9D9D9 */
+  --primary-sub-gray-2:  0 0% 61%;      /*중간 회색 #9C9C9C */
+  --primary-sub-gray-3:  0 0% 42%;      /*진한 회색 #6A6A6A */
 
-  --muted: 210 40% 96.1%;
-  --muted-foreground: 215.4 16.3% 46.9%;
+  /* Background(배경) / Text / Accent 색상*/
+  --background:          0 0% 94%;      /* 전체 배경색 #F0F0F0 */
+  --foreground:          0 0% 0%;       /* 기본 텍스트(검정) */
+ 
+  /* ▶ 텍스트 보조 색상 */
+  --text-main:           0 0% 0%;       /* #000000 */
+  --text-sub-blue:       227 61% 27%;   /* #1C306F */
+  --text-sub-white:      0 0% 100%;     /* #FFFFFF */
+  --text-sub-gray:       0 0% 61%;      /* #9C9C9C */
+  --text-sub-red:        3 86% 63%;     /* #F05750 */
 
-  --popover: 0 0% 100%;
-  --popover-foreground: 222.2 84% 4.9%;
+   /* ▶ Hover(버튼 등 눌렀을 때 효과) */
+  --hover:               226 60% 54%;   /* #4466D1 */
+  --hover-default:       0 0% 0%;
+  --hover-click:         226 60% 54%;
 
-  --card: 0 0% 100%;
-  --card-foreground: 222.2 84% 4.9%;
+/* ▶ shadcn UI 기본 변수와 연결 (figma 팔레트 색상으로 덮어쓰기) */
+  --card:                0 0% 100%;
+  --card-foreground:     var(--foreground);
 
-  --input: 214.3 31.8% 91.4%;
-  --ring: 222.2 84% 4.9%;
+  --muted:               210 10% 94%;
+  --muted-foreground:    215 16% 45%;
 
-  --primary: 222.2 47.4% 11.2%;
-  --primary-foreground: 210 40% 98%;
+  --popover:             0 0% 100%;
+  --popover-foreground:  var(--foreground);
 
-  --secondary: 210 40% 96.1%;
-  --secondary-foreground: 222.2 47.4% 11.2%;
+  --input:               210 10% 90%;
+  --ring:                var(--primary-main);
 
-  --accent: 210 40% 96.1%;
-  --accent-foreground: 222.2 47.4% 11.2%;
+  /* shadcn의 --primary / --secondary / --accent ▶ 라이브러리 표준 변수 (shadcn이 참고하는 이름)*/
+  --primary:             var(--primary-main);
+  --primary-foreground:  0 0% 100%;
 
-  --destructive: 0 84.2% 60.2%;
-  --destructive-foreground: 210 40% 98%;
+  --secondary:           210 10% 96%;
+  --secondary-foreground: 0 0% 10%;
 
-  --radius: 10px;
+  --accent:              48 100% 50%;   /* 강조 컬러 (노랑 #FFD600 등으로 바꿔도 됨) */
+  --accent-foreground:   0 0% 0%;
+
+  --destructive:         0 80% 60%;
+  --destructive-foreground: 0 0% 100%;
+
+  --border:              0 0% 0%;       /*테두리 색(검정) #000000 */
+  --radius:              24px;          /* 모서리 둥근 정도 */
+
+  /* 공통 타이포 라인하이트 */
+  --lh:                  150%;          /* 줄간격 */
 }
 
 
 @theme inline {
   /* MARK: - 기본 매핑 */
-  --color-background: hsl(var(--background));
-  --color-foreground: hsl(var(--foreground));
-  --color-card: hsl(var(--card));
-  --color-card-foreground: hsl(var(--card-foreground));
-  --color-primary: hsl(var(--primary));
-  --color-primary-foreground: hsl(var(--primary-foreground));
-  --color-border: hsl(var(--border));
-  --color-input: hsl(var(--input));
-  --color-ring: hsl(var(--ring));
+  /* Colors */
+  --color-background:           hsl(var(--background));
+  --color-foreground:           hsl(var(--foreground));
 
-  --font-sans: 'Pretendard';
+  --color-card:                 hsl(var(--card));
+  --color-card-foreground:      hsl(var(--card-foreground));
 
+  --color-primary:              hsl(var(--primary));
+  --color-primary-foreground:   hsl(var(--primary-foreground));
 
+  --color-border:               hsl(var(--border));
+  --color-input:                hsl(var(--input));
+  --color-ring:                 hsl(var(--ring));
+
+  /* 텍스트 */
+  --color-text-main:            hsl(var(--text-main));
+  --color-text-sub-blue:        hsl(var(--text-sub-blue));
+  --color-text-sub-gray:        hsl(var(--text-sub-gray));
+  --color-text-sub-red:         hsl(var(--text-sub-red));
+
+  /* hover 색상*/
+  --color-hover:                hsl(var(--hover));
+  --color-hover-click:          hsl(var(--hover-click));
+
+  /* 폰트 (Pretendard) */
+  --font-sans:                  'Pretendard', system-ui, 'Noto Sans KR', sans-serif;
+
+  /* 글자 크기 (pt → rem 변환) */
+  --text-display:   3.083rem;   /* 37pt ≈ 49.33px */
+  --text-h1:        2.333rem;   /* 28pt ≈ 37.33px */
+  --text-h2-22:     1.833rem;   /* 22pt ≈ 29.33px */
+  --text-h2-20:     1.667rem;   /* 20pt ≈ 26.67px */
+  --text-h2-18:     1.5rem;     /* 18pt = 24px */
+  --text-st1-16:    1.333rem;   /* 16pt ≈ 21.33px */
+  --text-st1-15:    1.25rem;    /* 15pt = 20px */
+  --text-st2-14:    1.167rem;   /* 14pt ≈ 18.67px */
+  --text-body1-12:  1rem;       /* 12pt = 16px */
 }
 @layer base {
   /* 기본 폰트, 배경색, 전역 스타일 지정 (선택사항) */
-  
+  html, body {
+    font-family: var(--font-sans);
+    line-height: var(--lh);
+    background: hsl(var(--background));
+    color: hsl(var(--foreground));
+  }  
 }
 
 @layer components {
   /* 전역적으로 재사용할 수 있는 커스텀 클래스 예시 */
- 
+  /* 기본 버튼 스타일 */
+  .btn-primary {
+    @apply inline-flex items-center justify-center px-5 py-3 font-bold
+           rounded-[var(--radius)]
+           text-[hsl(var(--primary-foreground))]
+           bg-[hsl(var(--primary))]
+           hover:bg-[hsl(var(--hover-click))];
+  }
+
+  /* 카드 박스 스타일 */
+  .card {
+    @apply bg-white rounded-[var(--radius)]
+           border border-[hsl(var(--border))] p-5;
+  }
+
+  /* 글자 크기 (피그마 기준) */
+  .typo-display { font-size: var(--text-display);  line-height: var(--lh); font-weight: 700; }
+  .typo-h1      { font-size: var(--text-h1);       line-height: var(--lh); font-weight: 700; }
+  .typo-h2-22   { font-size: var(--text-h2-22);    line-height: var(--lh); font-weight: 500; }
+  .typo-h2-20   { font-size: var(--text-h2-20);    line-height: var(--lh); font-weight: 500; }
+  .typo-h2-18   { font-size: var(--text-h2-18);    line-height: var(--lh); font-weight: 500; }
+  .typo-st1-16  { font-size: var(--text-st1-16);   line-height: var(--lh); font-weight: 500; }
+  .typo-st1-15  { font-size: var(--text-st1-15);   line-height: var(--lh); font-weight: 500; }
+  .typo-st2-14  { font-size: var(--text-st2-14);   line-height: var(--lh); font-weight: 500; }
+  .typo-body1   { font-size: var(--text-body1-12); line-height: var(--lh); font-weight: 400; } 
 }
 
+/* -----------------------------
+ 기타 유틸 클래스 (필요할 때 추가)
+------------------------------ */
 @layer utilities {
   /* 유틸리티 레벨에 추가할 사용자 정의 클래스 (선택사항) */
 }


### PR DESCRIPTION
## 변경 사항
- root 디자인 토큰 추가(Primary/Text/Background/Hover, radius)
- shadcn 표준 변수(--primary, --background 등) 피그마 팔레트로 매핑
- Pretendard 적용, 타입 스케일(37/28/22/20/18/16/15/14/12pt) 헬퍼 클래스 추가
- 버튼(.btn-primary), 카드(.card) 기본 유틸 제공