### PR TITLE
feat: Me 테마 카드 페이지들의 백엔드 API 연동 및 활동 기록 아카이브 페이지 구현

### DIFF
--- a/app/(cardThema)/me/(cards)/cd-001/page.tsx
+++ b/app/(cardThema)/me/(cards)/cd-001/page.tsx
@@ -1,26 +1,74 @@
 'use client';
 
+import { useState, useEffect } from 'react';
 import { useRouter } from 'next/navigation';
 import { CardDetailView } from '@/shared/ui/card-detail-view';
 import { BirthForm } from '@/features/cardThema/me/ui/birth-form';
 import { Button } from '@/shared/ui/button';
+import { createActivity } from '@/features/activity';
+import { scanQrCode } from '@/features/card';
+import { initialBirthData, type BirthData } from '@/features/cardThema/me/types';
+
+const QR_CODE = 'CD-001';
 
 export default function CardOfBirthPage() {
-  const router = useRouter();
-  return (
-    <>
-    <CardDetailView
-      cardNumber={1}
-      totalCards={5}
-      title='내가 태어난 날'
-      description='내가 태어난 날은 어떤일이 있었나요?'
-      frontImage='/cards-me/birth.svg'
-    />
-    <BirthForm/>
-    <Button
-      className='py-[19px] rounded-[12px] mt-5'
-      onClick={()=>router.push('/me/cd-002')}
-    >다음카드</Button>
-    </>
-  );
+    const router = useRouter();
+    const [formData, setFormData] = useState<BirthData>(initialBirthData);
+    const [cardId, setCardId] = useState<string | null>(null);
+    const [isLoading, setIsLoading] = useState(false);
+
+    // 카드 UUID 조회
+    useEffect(() => {
+        const fetchCardId = async () => {
+            try {
+                const card = await scanQrCode(QR_CODE);
+                setCardId(card.id);
+            } catch (error) {
+                console.error('카드 조회 실패:', error);
+            }
+        };
+        fetchCardId();
+    }, []);
+
+    const handleNext = async () => {
+        if (!cardId) {
+            console.error('카드 ID를 찾을 수 없습니다');
+            router.push('/me/cd-002');
+            return;
+        }
+
+        setIsLoading(true);
+        try {
+            await createActivity({
+                cardId,
+                activityResult: formData,
+            });
+            router.push('/me/cd-002');
+        } catch (error) {
+            console.error('활동 저장 실패:', error);
+            router.push('/me/cd-002');
+        } finally {
+            setIsLoading(false);
+        }
+    };
+
+    return (
+        <>
+            <CardDetailView
+                cardNumber={1}
+                totalCards={5}
+                title='내가 태어난 날'
+                description='내가 태어난 날은 어떤일이 있었나요?'
+                frontImage='/cards-me/birth.svg'
+            />
+            <BirthForm data={formData} onChange={setFormData} />
+            <Button
+                className='py-[19px] rounded-[12px] mt-5'
+                onClick={handleNext}
+                disabled={isLoading}
+            >
+                {isLoading ? '저장 중...' : '다음카드'}
+            </Button>
+        </>
+    );
 }

--- a/app/(cardThema)/me/(cards)/cd-002/page.tsx
+++ b/app/(cardThema)/me/(cards)/cd-002/page.tsx
@@ -1,26 +1,73 @@
 'use client';
 
+import { useState, useEffect } from 'react';
 import { useRouter } from 'next/navigation';
 import { CardDetailView } from '@/shared/ui/card-detail-view';
 import { NameForm } from '@/features/cardThema/me/ui/name-form';
 import { Button } from '@/shared/ui/button';
+import { createActivity } from '@/features/activity';
+import { scanQrCode } from '@/features/card';
+import { initialNameData, type NameData } from '@/features/cardThema/me/types';
+
+const QR_CODE = 'CD-002';
 
 export default function CardOfNamePage() {
     const router = useRouter();
+    const [formData, setFormData] = useState<NameData>(initialNameData);
+    const [cardId, setCardId] = useState<string | null>(null);
+    const [isLoading, setIsLoading] = useState(false);
+
+    useEffect(() => {
+        const fetchCardId = async () => {
+            try {
+                const card = await scanQrCode(QR_CODE);
+                setCardId(card.id);
+            } catch (error) {
+                console.error('카드 조회 실패:', error);
+            }
+        };
+        fetchCardId();
+    }, []);
+
+    const handleNext = async () => {
+        if (!cardId) {
+            console.error('카드 ID를 찾을 수 없습니다');
+            router.push('/me/cd-003');
+            return;
+        }
+
+        setIsLoading(true);
+        try {
+            await createActivity({
+                cardId,
+                activityResult: formData,
+            });
+            router.push('/me/cd-003');
+        } catch (error) {
+            console.error('활동 저장 실패:', error);
+            router.push('/me/cd-003');
+        } finally {
+            setIsLoading(false);
+        }
+    };
+
     return (
         <>
-        <CardDetailView
-            cardNumber={2}
-            totalCards={5}
-            title='나의 이름'
-            description='나의 이름에는 어떤 의미가 있나요?'
-            frontImage='/cards-me/name.svg'
-        />
-        <NameForm/>
-        <Button
-            className='py-[19px] rounded-[12px] mt-5'
-            onClick={()=>router.push('/me/cd-003')}
-        >다음카드</Button>
+            <CardDetailView
+                cardNumber={2}
+                totalCards={5}
+                title='나의 이름'
+                description='나의 이름에는 어떤 의미가 있나요?'
+                frontImage='/cards-me/name.svg'
+            />
+            <NameForm data={formData} onChange={setFormData} />
+            <Button
+                className='py-[19px] rounded-[12px] mt-5'
+                onClick={handleNext}
+                disabled={isLoading}
+            >
+                {isLoading ? '저장 중...' : '다음카드'}
+            </Button>
         </>
     );
 }

--- a/app/(cardThema)/me/(cards)/cd-003/page.tsx
+++ b/app/(cardThema)/me/(cards)/cd-003/page.tsx
@@ -1,17 +1,55 @@
 'use client';
 
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { useRouter } from 'next/navigation';
 import { CardDetailView } from '@/shared/ui/card-detail-view';
 import { MY_FEATURES } from '@/features/cardThema/me/constants/features';
 import { Button } from '@/shared/ui/button';
+import { createActivity } from '@/features/activity';
+import { scanQrCode } from '@/features/card';
+import { initialFeatureData, type FeatureData } from '@/features/cardThema/me/types';
+
+const QR_CODE = 'CD-003';
 
 export default function CardOfFeaturePage() {
     const router = useRouter();
-    const [selectedNature, setSelectedNature] = useState<number | null>(null);
-    const [selectedPersonal, setSelectedPersonal] = useState<number | null>(null);
-    const [selectedColor, setSelectedColor] = useState<number | null>(null);
-    const [selectedObject, setSelectedObject] = useState<number | null>(null);
+    const [formData, setFormData] = useState<FeatureData>(initialFeatureData);
+    const [cardId, setCardId] = useState<string | null>(null);
+    const [isLoading, setIsLoading] = useState(false);
+
+    useEffect(() => {
+        const fetchCardId = async () => {
+            try {
+                const card = await scanQrCode(QR_CODE);
+                setCardId(card.id);
+            } catch (error) {
+                console.error('카드 조회 실패:', error);
+            }
+        };
+        fetchCardId();
+    }, []);
+
+    const handleNext = async () => {
+        if (!cardId) {
+            console.error('카드 ID를 찾을 수 없습니다');
+            router.push('/me/cd-004');
+            return;
+        }
+
+        setIsLoading(true);
+        try {
+            await createActivity({
+                cardId,
+                activityResult: formData,
+            });
+            router.push('/me/cd-004');
+        } catch (error) {
+            console.error('활동 저장 실패:', error);
+            router.push('/me/cd-004');
+        } finally {
+            setIsLoading(false);
+        }
+    };
 
     return (
         <>
@@ -33,16 +71,16 @@ export default function CardOfFeaturePage() {
                             <button
                                 key={index}
                                 type='button'
-                                onClick={() => setSelectedNature(index)}
+                                onClick={() => setFormData(prev => ({ ...prev, nature: index }))}
                                 className={`w-full aspect-[149/80] rounded-[12px] flex flex-col items-center justify-center gap-1 transition-all ${
-                                    selectedNature === index
+                                    formData.nature === index
                                         ? 'bg-[#4466D1] text-white'
                                         : 'bg-white text-gray-900 hover:bg-gray-50'
                                 }`}
                             >
                                 <p className='text-2xl'>{item.icon}</p>
                                 <p className='font-medium'>{item.title}</p>
-                                <p className={`text-xs ${selectedNature === index ? 'text-white/80' : 'text-gray-500'}`}>
+                                <p className={`text-xs ${formData.nature === index ? 'text-white/80' : 'text-gray-500'}`}>
                                     {item.description}
                                 </p>
                             </button>
@@ -58,16 +96,16 @@ export default function CardOfFeaturePage() {
                             <button
                                 key={index}
                                 type='button'
-                                onClick={() => setSelectedPersonal(index)}
+                                onClick={() => setFormData(prev => ({ ...prev, personal: index }))}
                                 className={`w-full aspect-[149/80] rounded-[12px] flex flex-col items-center justify-center gap-1 transition-all ${
-                                    selectedPersonal === index
+                                    formData.personal === index
                                         ? 'bg-[#4466D1] text-white'
                                         : 'bg-white text-gray-900 hover:bg-gray-50'
                                 }`}
                             >
                                 <p className='text-2xl'>{item.icon}</p>
                                 <p className='font-medium'>{item.title}</p>
-                                <p className={`text-xs ${selectedPersonal === index ? 'text-white/80' : 'text-gray-500'}`}>
+                                <p className={`text-xs ${formData.personal === index ? 'text-white/80' : 'text-gray-500'}`}>
                                     {item.description}
                                 </p>
                             </button>
@@ -83,16 +121,16 @@ export default function CardOfFeaturePage() {
                             <button
                                 key={index}
                                 type='button'
-                                onClick={() => setSelectedColor(index)}
+                                onClick={() => setFormData(prev => ({ ...prev, color: index }))}
                                 className={`w-full aspect-[149/80] rounded-[12px] flex flex-col items-center justify-center gap-1 transition-all ${
-                                    selectedColor === index
+                                    formData.color === index
                                         ? 'bg-[#4466D1] text-white'
                                         : 'bg-white text-gray-900 hover:bg-gray-50'
                                 }`}
                             >
                                 <p className='text-2xl'>{item.icon}</p>
                                 <p className='font-medium'>{item.title}</p>
-                                <p className={`text-xs ${selectedColor === index ? 'text-white/80' : 'text-gray-500'}`}>
+                                <p className={`text-xs ${formData.color === index ? 'text-white/80' : 'text-gray-500'}`}>
                                     {item.description}
                                 </p>
                             </button>
@@ -108,16 +146,16 @@ export default function CardOfFeaturePage() {
                             <button
                                 key={index}
                                 type='button'
-                                onClick={() => setSelectedObject(index)}
+                                onClick={() => setFormData(prev => ({ ...prev, object: index }))}
                                 className={`w-full aspect-[149/80] rounded-[12px] flex flex-col items-center justify-center gap-1 transition-all ${
-                                    selectedObject === index
+                                    formData.object === index
                                         ? 'bg-[#4466D1] text-white'
                                         : 'bg-white text-gray-900 hover:bg-gray-50'
                                 }`}
                             >
                                 <p className='text-2xl'>{item.icon}</p>
                                 <p className='font-medium'>{item.title}</p>
-                                <p className={`text-xs ${selectedObject === index ? 'text-white/80' : 'text-gray-500'}`}>
+                                <p className={`text-xs ${formData.object === index ? 'text-white/80' : 'text-gray-500'}`}>
                                     {item.description}
                                 </p>
                             </button>
@@ -125,12 +163,17 @@ export default function CardOfFeaturePage() {
                     </div>
                 </section>
             </div>
-            
+
             <footer className='w-full flex gap-4 mt-5'>
-                <Button status='inactive' className='flex-1 py-[19px] rounded-[12px]' onClick={()=>router.back()}>이전으로</Button>
-                <Button className='flex-1 py-[19px] rounded-[12px]' onClick={()=>router.push('/me/cd-004')}>다음으로</Button>
+                <Button status='inactive' className='flex-1 py-[19px] rounded-[12px]' onClick={() => router.back()}>이전으로</Button>
+                <Button
+                    className='flex-1 py-[19px] rounded-[12px]'
+                    onClick={handleNext}
+                    disabled={isLoading}
+                >
+                    {isLoading ? '저장 중...' : '다음으로'}
+                </Button>
             </footer>
         </>
-
     );
 }

--- a/app/(cardThema)/me/(cards)/cd-004/page.tsx
+++ b/app/(cardThema)/me/(cards)/cd-004/page.tsx
@@ -1,13 +1,56 @@
 'use client';
 
+import { useState, useEffect } from 'react';
 import { useRouter } from 'next/navigation';
 import { CardDetailView } from '@/shared/ui/card-detail-view';
 import { InputBox } from '@/shared/ui/input-box';
 import { Button } from '@/shared/ui/button';
-// import { MY_FEATURES } from '@/features/cardThema/me/constants/taste';
+import { createActivity } from '@/features/activity';
+import { scanQrCode } from '@/features/card';
+import { initialTasteData, type TasteData } from '@/features/cardThema/me/types';
+
+const QR_CODE = 'CD-004';
 
 export default function CardOfTastePage() {
     const router = useRouter();
+    const [formData, setFormData] = useState<TasteData>(initialTasteData);
+    const [cardId, setCardId] = useState<string | null>(null);
+    const [isLoading, setIsLoading] = useState(false);
+
+    useEffect(() => {
+        const fetchCardId = async () => {
+            try {
+                const card = await scanQrCode(QR_CODE);
+                setCardId(card.id);
+            } catch (error) {
+                console.error('카드 조회 실패:', error);
+            }
+        };
+        fetchCardId();
+    }, []);
+
+    const handleNext = async () => {
+        if (!cardId) {
+            console.error('카드 ID를 찾을 수 없습니다');
+            router.push('/me/cd-005');
+            return;
+        }
+
+        setIsLoading(true);
+        try {
+            await createActivity({
+                cardId,
+                activityResult: formData,
+            });
+            router.push('/me/cd-005');
+        } catch (error) {
+            console.error('활동 저장 실패:', error);
+            router.push('/me/cd-005');
+        } finally {
+            setIsLoading(false);
+        }
+    };
+
     return (
         <>
             <CardDetailView
@@ -23,20 +66,35 @@ export default function CardOfTastePage() {
 
                 <section className='flex flex-col gap-2'>
                     <label className='text-sm font-medium text-gray-700'>어제 먹었던 음식은?</label>
-                    <InputBox placeholder='내가 어제 먹었던 음식을 적어주세요' className='bg-white py-3 rounded-[12px]'/>
+                    <InputBox
+                        placeholder='내가 어제 먹었던 음식을 적어주세요'
+                        className='bg-white py-3 rounded-[12px]'
+                        value={formData.yesterdayFood}
+                        onChange={(e) => setFormData(prev => ({ ...prev, yesterdayFood: e.target.value }))}
+                    />
                 </section>
 
                 <section className='flex flex-col gap-2'>
                     <label className='text-sm font-medium text-gray-700'>내일은 무엇을 먹을까요?</label>
-                    <InputBox placeholder='내일 무엇을 먹을지 적어주세요' className='bg-white py-3 rounded-[12px]'/>
+                    <InputBox
+                        placeholder='내일 무엇을 먹을지 적어주세요'
+                        className='bg-white py-3 rounded-[12px]'
+                        value={formData.tomorrowFood}
+                        onChange={(e) => setFormData(prev => ({ ...prev, tomorrowFood: e.target.value }))}
+                    />
                 </section>
             </main>
 
             <footer className='w-full flex gap-5 mt-5'>
-                <Button status='inactive' className='flex-1 py-[19px] rounded-[12px]' onClick={()=>router.back()}>이전으로</Button>
-                <Button className='flex-1 py-[19px] rounded-[12px]' onClick={()=>router.push('/me/cd-005')}>다음으로</Button>
+                <Button status='inactive' className='flex-1 py-[19px] rounded-[12px]' onClick={() => router.back()}>이전으로</Button>
+                <Button
+                    className='flex-1 py-[19px] rounded-[12px]'
+                    onClick={handleNext}
+                    disabled={isLoading}
+                >
+                    {isLoading ? '저장 중...' : '다음으로'}
+                </Button>
             </footer>
         </>
-
     );
 }

--- a/app/(cardThema)/me/(cards)/cd-005/page.tsx
+++ b/app/(cardThema)/me/(cards)/cd-005/page.tsx
@@ -1,16 +1,55 @@
 'use client';
 
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { useRouter } from 'next/navigation';
 import { CardDetailView } from '@/shared/ui/card-detail-view';
-import { Button } from '@/shared/ui/button'
+import { Button } from '@/shared/ui/button';
 import { MY_FEATURES } from '@/features/cardThema/me/constants/sound';
+import { createActivity } from '@/features/activity';
+import { scanQrCode } from '@/features/card';
+import { initialSoundData, type SoundData } from '@/features/cardThema/me/types';
+
+const QR_CODE = 'CD-005';
 
 export default function CardOfSoundPage() {
     const router = useRouter();
-    const [selectedVoice, setSelectedVoice] = useState<number | null>(null);
-    const [selectedNature, setSelectedNature] = useState<number | null>(null);
-    const [selectedGeneral, setSelectedGeneral] = useState<number | null>(null);
+    const [formData, setFormData] = useState<SoundData>(initialSoundData);
+    const [cardId, setCardId] = useState<string | null>(null);
+    const [isLoading, setIsLoading] = useState(false);
+
+    useEffect(() => {
+        const fetchCardId = async () => {
+            try {
+                const card = await scanQrCode(QR_CODE);
+                setCardId(card.id);
+            } catch (error) {
+                console.error('카드 조회 실패:', error);
+            }
+        };
+        fetchCardId();
+    }, []);
+
+    const handleComplete = async () => {
+        if (!cardId) {
+            console.error('카드 ID를 찾을 수 없습니다');
+            router.push('/me');
+            return;
+        }
+
+        setIsLoading(true);
+        try {
+            await createActivity({
+                cardId,
+                activityResult: formData,
+            });
+            router.push('/me');
+        } catch (error) {
+            console.error('활동 저장 실패:', error);
+            router.push('/me');
+        } finally {
+            setIsLoading(false);
+        }
+    };
 
     return (
         <>
@@ -31,9 +70,9 @@ export default function CardOfSoundPage() {
                             <button
                                 key={index}
                                 type='button'
-                                onClick={() => setSelectedVoice(index)}
+                                onClick={() => setFormData(prev => ({ ...prev, voice: index }))}
                                 className={`aspect-[149/80] flex flex-col items-center justify-center py-2 px-[14px] rounded-[12px] transition-all ${
-                                    selectedVoice === index
+                                    formData.voice === index
                                         ? 'bg-[#4466D1] text-white'
                                         : 'bg-white text-gray-900 hover:bg-gray-50'
                                 }`}
@@ -53,9 +92,9 @@ export default function CardOfSoundPage() {
                             <button
                                 key={index}
                                 type='button'
-                                onClick={() => setSelectedNature(index)}
+                                onClick={() => setFormData(prev => ({ ...prev, nature: index }))}
                                 className={`aspect-[149/80] flex flex-col items-center justify-center py-2 px-[14px] rounded-[12px] transition-all ${
-                                    selectedNature === index
+                                    formData.nature === index
                                         ? 'bg-[#4466D1] text-white'
                                         : 'bg-white text-gray-900 hover:bg-gray-50'
                                 }`}
@@ -75,9 +114,9 @@ export default function CardOfSoundPage() {
                             <button
                                 key={index}
                                 type='button'
-                                onClick={() => setSelectedGeneral(index)}
+                                onClick={() => setFormData(prev => ({ ...prev, general: index }))}
                                 className={`aspect-[98/72] flex flex-col items-center justify-center py-2 px-[14px] rounded-[12px] transition-all ${
-                                    selectedGeneral === index
+                                    formData.general === index
                                         ? 'bg-[#4466D1] text-white'
                                         : 'bg-white text-gray-900 hover:bg-gray-50'
                                 }`}
@@ -92,8 +131,14 @@ export default function CardOfSoundPage() {
             </main>
 
             <footer className='w-full flex gap-5 mt-5 mb-25'>
-                <Button status='inactive' className='flex-1 py-[19px] rounded-[12px]' onClick={()=>router.back()}>이전으로</Button>
-                <Button className='flex-1 py-[19px] rounded-[12px]'>완료하기</Button>
+                <Button status='inactive' className='flex-1 py-[19px] rounded-[12px]' onClick={() => router.back()}>이전으로</Button>
+                <Button
+                    className='flex-1 py-[19px] rounded-[12px]'
+                    onClick={handleComplete}
+                    disabled={isLoading}
+                >
+                    {isLoading ? '저장 중...' : '완료하기'}
+                </Button>
             </footer>
         </>
     );

--- a/app/(cardThema)/place/(cards)/cd-011/page.tsx
+++ b/app/(cardThema)/place/(cards)/cd-011/page.tsx
@@ -5,7 +5,6 @@ import { CardDetailView } from '@/shared/ui/card-detail-view';
 import { Button } from '@/shared/ui/button';
 import { HomeSelect } from '@/features/cardThema/place/ui/home-select';
 import { OutsideSelect } from '@/features/cardThema/place/ui/outside-select';
-import { FormList } from '@/shared/ui/form-list';
 import { InputBox } from '@/shared/ui/input-box';
 
 const fileds = [

--- a/app/archive/page.tsx
+++ b/app/archive/page.tsx
@@ -1,23 +1,421 @@
 'use client';
 
-import { Container } from "@/shared/ui/container";
+import { useState, useEffect, useRef } from 'react';
+import Image from 'next/image';
 import { BottomNavigation } from "@/shared/ui/bottom-nav";
 import { useAuthGuard } from '@/features/auth/hooks/useAuthGuard';
 import { AuthLoading } from '@/shared/ui/auth-loading';
+import { getMyActivities, type ActivityResponse } from '@/features/activity';
+import { getCard, type CardResponse } from '@/features/card';
+
+// MARK: 활동 + 카드 정보 타입
+interface ActivityWithCard extends ActivityResponse {
+    card: CardResponse | undefined;
+}
+
+// MARK: 라벨 포맷팅 (camelCase → 한글)
+const LABEL_MAP: Record<string, string> = {
+    // 공통
+    name: '이름',
+    title: '제목',
+    content: '내용',
+    description: '설명',
+    memo: '메모',
+    date: '날짜',
+    time: '시간',
+    place: '장소',
+
+    // cd-001: 내가 태어난 날
+    birthday: '생일',
+    birthYear: '태어난 해',
+    birthSeason: '태어난 계절',
+    babyDream: '나의 태몽',
+    zodiac: '나의 띠',
+
+    // cd-002: 나의 이름
+    nameMeaning: '이름의 의미',
+    nameGiver: '이름을 지어준 사람',
+    nickname: '별명',
+    nicknameGiver: '별명을 지어준 사람',
+
+    // cd-003: 나의 기질
+    nature: '자연',
+    personal: '동물',
+    color: '색상',
+    object: '일상소품',
+
+    // cd-004: 나의 입맛
+    yesterdayFood: '어제 먹은 음식',
+    tomorrowFood: '내일 먹을 음식',
+
+    // cd-005: 나의 소리
+    voice: '목소리 톤',
+    general: '일상의 소리',
+};
+
+// MARK: 인덱스 → 실제 값 변환 (선택형 필드용)
+const INDEX_VALUE_MAP: Record<string, { icon: string; name: string }[]> = {
+    // cd-003: 나의 기질
+    nature: [
+        { icon: '🔥', name: '불 (열정적, 급함)' },
+        { icon: '💧', name: '물 (유연함, 온화함)' },
+        { icon: '🍃', name: '바람 (자유로움)' },
+        { icon: '🪨', name: '돌 (묵직함, 신중함)' },
+    ],
+    personal: [
+        { icon: '🐇', name: '토끼 (수줍음, 민감함)' },
+        { icon: '🐅', name: '호랑이 (용감, 리더십)' },
+        { icon: '🐢', name: '거북이 (느긋함)' },
+        { icon: '🦜', name: '새 (자유로움, 호기심)' },
+    ],
+    color: [
+        { icon: '🔴', name: '빨강 (강렬, 활발)' },
+        { icon: '🔵', name: '파랑 (차분, 이성)' },
+        { icon: '🟡', name: '노랑 (명랑, 유쾌)' },
+        { icon: '🟢', name: '초록 (평화, 조화)' },
+    ],
+    object: [
+        { icon: '📚', name: '책 (사색형)' },
+        { icon: '👟', name: '신발 (활동형)' },
+        { icon: '🕯', name: '촛불 (감성)' },
+        { icon: '⏰️', name: '시계 (계획적)' },
+    ],
+    // cd-005: 나의 소리
+    voice: [
+        { icon: '🦁', name: '낮고 굵은' },
+        { icon: '🎶', name: '맑고 높은' },
+        { icon: '☁️', name: '부드러운' },
+        { icon: '⚡', name: '힘 있는' },
+    ],
+    natureSounds: [
+        { icon: '☔', name: '빗소리' },
+        { icon: '🌊', name: '파도소리' },
+        { icon: '🍃', name: '바람소리' },
+        { icon: '🕊️', name: '새소리' },
+        { icon: '🌳', name: '매미소리' },
+        { icon: '🦗', name: '풀벌레 소리' },
+        { icon: '🍂', name: '낙엽밟는 소리' },
+        { icon: '❄️', name: '눈 쌓이는 소리' },
+        { icon: '🔥', name: '장작타는 소리' },
+    ],
+    general: [
+        { icon: '📻', name: '라디오 소리' },
+        { icon: '🐈', name: '반려동물 소리' },
+        { icon: '🍳', name: '음식하는 소리' },
+    ],
+};
+
+function formatLabel(key: string): string {
+    if (LABEL_MAP[key]) return LABEL_MAP[key];
+    return key.replace(/([A-Z])/g, ' $1').replace(/^./, str => str.toUpperCase());
+}
+
+function formatValue(key: string, value: unknown): string {
+    // null 또는 undefined
+    if (value === null || value === undefined) return '-';
+
+    // 숫자(인덱스)인 경우 매핑 확인
+    if (typeof value === 'number' && INDEX_VALUE_MAP[key]) {
+        const item = INDEX_VALUE_MAP[key][value];
+        if (item) return `${item.icon} ${item.name}`;
+    }
+
+    return String(value);
+}
 
 export default function ArchivePage() {
     const { isChecking } = useAuthGuard();
+    const [activities, setActivities] = useState<ActivityWithCard[]>([]);
+    const [currentIndex, setCurrentIndex] = useState(0);
+    const [isLoading, setIsLoading] = useState(true);
+    const [isAnimating, setIsAnimating] = useState(false);
+    const [isFlipped, setIsFlipped] = useState(false);
+
+    // 터치 스와이프
+    const touchStartX = useRef(0);
+    const touchEndX = useRef(0);
+
+    useEffect(() => {
+        const fetchActivities = async () => {
+            try {
+                const response = await getMyActivities({ limit: 100 });
+                const activitiesWithCards: ActivityWithCard[] = await Promise.all(
+                    response.items.map(async (activity): Promise<ActivityWithCard> => {
+                        try {
+                            const card = await getCard(activity.cardId);
+                            return { ...activity, card };
+                        } catch {
+                            return { ...activity, card: undefined };
+                        }
+                    })
+                );
+                setActivities(activitiesWithCards);
+            } catch (error) {
+                console.error('활동 조회 실패:', error);
+            } finally {
+                setIsLoading(false);
+            }
+        };
+        fetchActivities();
+    }, []);
+
+    const goTo = (index: number) => {
+        if (isAnimating || index === currentIndex) return;
+        setIsFlipped(false); // 카드 전환 시 플립 초기화
+        setIsAnimating(true);
+        setCurrentIndex(index);
+        setTimeout(() => setIsAnimating(false), 600);
+    };
+
+    const handlePrev = () => {
+        if (isAnimating) return;
+        goTo(currentIndex === 0 ? activities.length - 1 : currentIndex - 1);
+    };
+
+    const handleNext = () => {
+        if (isAnimating) return;
+        goTo(currentIndex === activities.length - 1 ? 0 : currentIndex + 1);
+    };
+
+    const handleTouchStart = (e: React.TouchEvent) => {
+        touchStartX.current = e.touches[0].clientX;
+        touchEndX.current = e.touches[0].clientX;
+    };
+
+    const handleTouchMove = (e: React.TouchEvent) => {
+        touchEndX.current = e.touches[0].clientX;
+    };
+
+    const handleTouchEnd = () => {
+        const diff = touchStartX.current - touchEndX.current;
+
+        // 스와이프: 50px 이상 이동
+        if (Math.abs(diff) > 50) {
+            if (diff > 0) handleNext();
+            else handlePrev();
+        }
+    };
+
+    // 카드 위치 계산 (3D 스택 효과)
+    const getCardStyle = (index: number) => {
+        const diff = index - currentIndex;
+        const absDiff = Math.abs(diff);
+
+        if (absDiff > 2) {
+            return { opacity: 0, transform: 'scale(0.8) translateX(0)', zIndex: 0 };
+        }
+
+        const baseTranslate = diff * 60;
+        const scale = 1 - absDiff * 0.12;
+        const opacity = 1 - absDiff * 0.4;
+        const rotateY = diff * -8;
+        const translateZ = -absDiff * 50;
+
+        return {
+            opacity,
+            transform: `perspective(1000px) translateX(${baseTranslate}px) translateZ(${translateZ}px) scale(${scale}) rotateY(${rotateY}deg)`,
+            zIndex: 10 - absDiff,
+        };
+    };
 
     if (isChecking) return <AuthLoading />;
 
     return (
-        <div className="min-h-screen flex flex-col bg-[#F0F0F0] full-bleed pb-[60px]">
-                <div className="flex-1 flex items-center justify-center">
-                <Container>
-                    <h1 className="text-2xl font-bold mb-6">어떤 테마로 시작해볼까요?</h1>
-                </Container>
-                </div>
-                <BottomNavigation />
+        <div className="min-h-screen flex flex-col bg-gradient-to-b from-[#F8F9FF] to-[#F0F0F0] full-bleed pb-[88px]">
+            <div className="w-full max-w-[430px] mx-auto flex flex-col flex-1">
+                <header className="px-5 py-6">
+                    <h1 className="text-2xl font-bold text-gray-900">나의 활동 기록</h1>
+                    <p className="text-gray-500 mt-1">완료한 카드 미션을 확인해보세요</p>
+                </header>
+
+                <main className="flex-1 px-5">
+                    {isLoading ? (
+                        <div className="flex items-center justify-center py-20">
+                            <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-[#4E73FF]" />
+                        </div>
+                    ) : activities.length === 0 ? (
+                        <div className="text-center py-20">
+                            <p className="text-6xl mb-4">📭</p>
+                            <p className="text-gray-500">아직 완료한 활동이 없어요</p>
+                            <p className="text-gray-400 text-sm mt-1">카드 미션을 시작해보세요!</p>
+                        </div>
+                    ) : (
+                        <div className="relative">
+                            {/* MARK: 3D 카드 스택 */}
+                            <div
+                                className="relative h-[380px] flex items-center justify-center overflow-visible"
+                                onTouchStart={handleTouchStart}
+                                onTouchMove={handleTouchMove}
+                                onTouchEnd={handleTouchEnd}
+                            >
+                                {activities.map((activity, index) => {
+                                    const style = getCardStyle(index);
+                                    const isCurrent = index === currentIndex;
+                                    const shouldFlip = isCurrent && isFlipped;
+
+                                    return (
+                                        <div
+                                            key={activity.id}
+                                            className="absolute transition-all duration-600 ease-[cubic-bezier(0.23,1,0.32,1)] cursor-pointer"
+                                            style={{
+                                                ...style,
+                                                transitionDuration: '600ms',
+                                                perspective: '1000px',
+                                            }}
+                                            onClick={() => isCurrent ? setIsFlipped(!isFlipped) : goTo(index)}
+                                        >
+                                            {/* 플립 컨테이너 */}
+                                            <div
+                                                className="relative transition-transform duration-700 ease-out"
+                                                style={{
+                                                    transformStyle: 'preserve-3d',
+                                                    transform: shouldFlip ? 'rotateY(180deg)' : 'rotateY(0deg)',
+                                                }}
+                                            >
+                                                {/* 앞면: 카드 이미지 */}
+                                                <div
+                                                    className="relative"
+                                                    style={{ backfaceVisibility: 'hidden' }}
+                                                >
+                                                    <div className="relative bg-white rounded-2xl p-3 shadow-xl">
+                                                        {activity.card?.thumbnailUrl ? (
+                                                            <Image
+                                                                src={activity.card.thumbnailUrl}
+                                                                alt={activity.card.title || '카드'}
+                                                                width={160}
+                                                                height={220}
+                                                                className="rounded-xl"
+                                                            />
+                                                        ) : (
+                                                            <div className="w-[160px] h-[220px] rounded-xl bg-gradient-to-br from-[#4E73FF]/10 via-[#6B4EFF]/5 to-[#4E8FFF]/10 flex items-center justify-center text-5xl">
+                                                                📄
+                                                            </div>
+                                                        )}
+                                                        {/* 탭 힌트 */}
+                                                        {isCurrent && !isFlipped && (
+                                                            <div className="absolute bottom-2 left-1/2 -translate-x-1/2 text-xs text-gray-400 bg-white/80 px-2 py-0.5 rounded-full">
+                                                                탭하여 내용 보기
+                                                            </div>
+                                                        )}
+                                                    </div>
+                                                </div>
+
+                                                {/* 뒷면: 활동 내용 */}
+                                                <div
+                                                    className="absolute inset-0"
+                                                    style={{
+                                                        backfaceVisibility: 'hidden',
+                                                        transform: 'rotateY(180deg)',
+                                                    }}
+                                                >
+                                                    <div className="w-[186px] h-[246px] bg-gradient-to-br from-[#4E73FF] to-[#6B4EFF] rounded-2xl p-4 shadow-xl overflow-hidden">
+                                                        <div className="h-full flex flex-col">
+                                                            <h5 className="text-white font-bold text-sm mb-3 truncate">
+                                                                {activity.card?.title || '활동 내용'}
+                                                            </h5>
+                                                            <div className="flex-1 overflow-y-auto space-y-2 text-xs scrollbar-hide">
+                                                                {activity.activityResult && typeof activity.activityResult === 'object' ? (
+                                                                    Object.entries(activity.activityResult).map(([key, value]) => (
+                                                                        <div key={key} className="bg-white/20 rounded-lg p-2">
+                                                                            <p className="text-white/70 text-[10px] uppercase tracking-wide">{formatLabel(key)}</p>
+                                                                            <p className="text-white font-medium mt-0.5 break-words">{formatValue(key, value)}</p>
+                                                                        </div>
+                                                                    ))
+                                                                ) : (
+                                                                    <p className="text-white/80">내용이 없습니다</p>
+                                                                )}
+                                                            </div>
+                                                            <p className="text-white/60 text-[10px] mt-2 text-center">
+                                                                탭하여 돌아가기
+                                                            </p>
+                                                        </div>
+                                                    </div>
+                                                </div>
+                                            </div>
+                                        </div>
+                                    );
+                                })}
+                            </div>
+
+                            {/* MARK: 카드 정보 (페이드 인) */}
+                            <div className="text-center mt-4 h-[80px]">
+                                {activities.map((activity, index) => (
+                                    <div
+                                        key={`info-${activity.id}`}
+                                        className={`absolute left-0 right-0 transition-all duration-500 ${
+                                            index === currentIndex
+                                                ? 'opacity-100 translate-y-0'
+                                                : 'opacity-0 translate-y-4 pointer-events-none'
+                                        }`}
+                                    >
+                                        <h4 className="font-bold text-xl text-gray-900">
+                                            {activity.card?.title || '카드 제목'}
+                                        </h4>
+                                        <p className="text-sm text-gray-500 mt-1">
+                                            {new Date(activity.completedAt).toLocaleDateString('ko-KR', {
+                                                year: 'numeric',
+                                                month: 'long',
+                                                day: 'numeric'
+                                            })}
+                                        </p>
+                                    </div>
+                                ))}
+                            </div>
+
+                            {/* MARK: 네비게이션 */}
+                            {activities.length > 1 && (
+                                <div className="flex items-center justify-center gap-6 mt-6">
+                                    <button
+                                        type="button"
+                                        onClick={handlePrev}
+                                        className="w-12 h-12 bg-white rounded-full flex items-center justify-center shadow-lg transition-all duration-300 hover:scale-110 hover:shadow-xl active:scale-95 hover:bg-[#4E73FF] group"
+                                    >
+                                        <ChevronIcon className="w-5 h-5 text-gray-600 rotate-90 group-hover:text-white transition-colors" />
+                                    </button>
+
+                                    {/* 인디케이터 */}
+                                    <div className="flex gap-2">
+                                        {activities.map((activity, index) => (
+                                            <button
+                                                type="button"
+                                                key={activity.id}
+                                                onClick={() => goTo(index)}
+                                                className={`rounded-full transition-all duration-500 ${
+                                                    index === currentIndex
+                                                        ? 'bg-[#4E73FF] w-8 h-3'
+                                                        : 'bg-gray-300 w-3 h-3 hover:bg-[#4E73FF]/50'
+                                                }`}
+                                            />
+                                        ))}
+                                    </div>
+
+                                    <button
+                                        type="button"
+                                        onClick={handleNext}
+                                        className="w-12 h-12 bg-white rounded-full flex items-center justify-center shadow-lg transition-all duration-300 hover:scale-110 hover:shadow-xl active:scale-95 hover:bg-[#4E73FF] group"
+                                    >
+                                        <ChevronIcon className="w-5 h-5 text-gray-600 -rotate-90 group-hover:text-white transition-colors" />
+                                    </button>
+                                </div>
+                            )}
+
+                            {/* 카운트 */}
+                            <p className="text-center text-sm text-gray-400 mt-4">
+                                {currentIndex + 1} / {activities.length}
+                            </p>
+                        </div>
+                    )}
+                </main>
+            </div>
+            <BottomNavigation className="max-w-[430px] mx-auto w-full" />
         </div>
+    );
+}
+
+function ChevronIcon({ className }: { className?: string }) {
+    return (
+        <svg className={className} fill="none" viewBox="0 0 24 24" stroke="currentColor">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
+        </svg>
     );
 }

--- a/src/features/activity/api/activity-api.ts
+++ b/src/features/activity/api/activity-api.ts
@@ -1,0 +1,27 @@
+// MARK: Activity 관련 API 호출
+import { apiClient } from '@/shared/api/client';
+import type { ActivityCreate, ActivityResponse, PaginatedResponse } from './types';
+
+// MARK: 활동 기록 생성
+export async function createActivity<T>(data: ActivityCreate<T>): Promise<ActivityResponse> {
+    const response = await apiClient.post<ActivityResponse>('/api/activities', data);
+    return response.data;
+}
+
+// MARK: 내 활동 목록 조회
+export async function getMyActivities(params?: {
+    skip?: number;
+    limit?: number;
+}): Promise<PaginatedResponse<ActivityResponse>> {
+    const response = await apiClient.get<PaginatedResponse<ActivityResponse>>('/api/activities/me', {
+        params,
+    });
+    return response.data;
+}
+
+// MARK: 활동 상세 조회
+export async function getActivity(activityId: string): Promise<ActivityResponse> {
+    const response = await apiClient.get<ActivityResponse>(`/api/activities/${activityId}`);
+    return response.data;
+}
+

--- a/src/features/activity/api/types.ts
+++ b/src/features/activity/api/types.ts
@@ -1,0 +1,27 @@
+// MARK: Activity API 타입 정의
+
+// 활동 기록 생성 요청
+export interface ActivityCreate<T = Record<string, unknown>> {
+    cardId: string;
+    activityResult: T;
+}
+
+// 활동 기록 응답
+export interface ActivityResponse {
+    id: string;
+    userId: string;
+    cardId: string;
+    activityResult: Record<string, unknown>;
+    completedAt: string;
+    createdAt: string;
+}
+
+// 페이지네이션 응답
+export interface PaginatedResponse<T> {
+    items: T[];
+    total: number;
+    page: number;
+    page_size: number;
+    total_pages: number;
+}
+

--- a/src/features/activity/index.ts
+++ b/src/features/activity/index.ts
@@ -1,0 +1,4 @@
+// MARK: Activity Feature Export
+export * from './api/activity-api';
+export * from './api/types';
+

--- a/src/features/card/index.ts
+++ b/src/features/card/index.ts
@@ -1,0 +1,4 @@
+// MARK: Card Feature Exports
+export { scanQrCode, getCards, getCard } from './api/card-api';
+export type { CardResponse, CardListResponse, PaginatedResponse } from './api/types';
+

--- a/src/features/cardThema/me/types.ts
+++ b/src/features/cardThema/me/types.ts
@@ -1,0 +1,85 @@
+// MARK: Me 테마 카드별 데이터 타입 정의
+
+// cd-001: 내가 태어난 날
+export interface BirthData {
+    birthday: string;           // 생일
+    birthYear: string;          // 태어난 해 (그 해의 사건)
+    birthSeason: string;        // 태어난 계절
+    babyDream: string;          // 나의 태몽
+    zodiac: string;             // 나의 띠
+}
+
+// cd-002: 나의 이름
+export interface NameData {
+    name: string;               // 나의 이름
+    nameMeaning: string;        // 이름이 가진 의미
+    nameGiver: string;          // 이름을 지어준 사람
+    nickname: string;           // 내가 좋아하는 별명
+    nicknameGiver: string;      // 별명을 지어준 사람
+}
+
+// cd-003: 나의 기질
+export interface FeatureData {
+    nature: number | null;      // 자연 (0-3)
+    personal: number | null;    // 동물 (0-3)
+    color: number | null;       // 색상 (0-3)
+    object: number | null;      // 일상소품 (0-3)
+}
+
+// cd-004: 나의 입맛
+export interface TasteData {
+    yesterdayFood: string;      // 어제 먹었던 음식
+    tomorrowFood: string;       // 내일 먹을 음식
+}
+
+// cd-005: 나의 소리
+export interface SoundData {
+    voice: number | null;       // 목소리 톤 (0-3)
+    nature: number | null;      // 자연의 소리 (0-8)
+    general: number | null;     // 일상의 소리 (0-2)
+}
+
+// Me 테마 전체 데이터 통합
+export interface MeThemeData {
+    birth?: BirthData;
+    name?: NameData;
+    feature?: FeatureData;
+    taste?: TasteData;
+    sound?: SoundData;
+}
+
+// 초기값 정의
+export const initialBirthData: BirthData = {
+    birthday: '',
+    birthYear: '',
+    birthSeason: '',
+    babyDream: '',
+    zodiac: '',
+};
+
+export const initialNameData: NameData = {
+    name: '',
+    nameMeaning: '',
+    nameGiver: '',
+    nickname: '',
+    nicknameGiver: '',
+};
+
+export const initialFeatureData: FeatureData = {
+    nature: null,
+    personal: null,
+    color: null,
+    object: null,
+};
+
+export const initialTasteData: TasteData = {
+    yesterdayFood: '',
+    tomorrowFood: '',
+};
+
+export const initialSoundData: SoundData = {
+    voice: null,
+    nature: null,
+    general: null,
+};
+

--- a/src/features/cardThema/me/ui/birth-form.tsx
+++ b/src/features/cardThema/me/ui/birth-form.tsx
@@ -1,13 +1,31 @@
+'use client';
+
 import { FormList } from "@/shared/ui/form-list";
+import type { BirthData } from "../types";
 
 const birthFields = [
-    { label: "생일", placeholder: '생일은 언제인가요?' },
-    { label: "태어난 해", placeholder: '그 해, 나에게는 어떤 일이 있었나요?' },
-    { label: "태어난 계절", placeholder: '태어난 계절은 언제인가요?' },
-    { label: "나의 태몽", placeholder: '나의 태몽은 무엇인가요?' },
-    { label: "나의 띠", placeholder: '내 띠는 무엇인가요?' }
+    { key: 'birthday', label: "생일", placeholder: '생일은 언제인가요?' },
+    { key: 'birthYear', label: "태어난 해", placeholder: '그 해, 나에게는 어떤 일이 있었나요?' },
+    { key: 'birthSeason', label: "태어난 계절", placeholder: '태어난 계절은 언제인가요?' },
+    { key: 'babyDream', label: "나의 태몽", placeholder: '나의 태몽은 무엇인가요?' },
+    { key: 'zodiac', label: "나의 띠", placeholder: '내 띠는 무엇인가요?' }
 ];
 
-export function BirthForm() {
-    return <FormList fields={birthFields} />;
+interface BirthFormProps {
+    data: BirthData;
+    onChange: (data: BirthData) => void;
+}
+
+export function BirthForm({ data, onChange }: BirthFormProps) {
+    const handleChange = (key: string, value: string) => {
+        onChange({ ...data, [key]: value });
+    };
+
+    return (
+        <FormList
+            fields={birthFields}
+            values={data}
+            onChange={handleChange}
+        />
+    );
 }

--- a/src/features/cardThema/me/ui/name-form.tsx
+++ b/src/features/cardThema/me/ui/name-form.tsx
@@ -1,13 +1,31 @@
+'use client';
+
 import { FormList } from "@/shared/ui/form-list";
+import type { NameData } from "../types";
 
 const nameFields = [
-    { label: "나의 이름은?", placeholder: '이름이 무엇인가요?' },
-    { label: "이름이 가진 의미", placeholder: '내 이름의 의미는 무엇인가요?' },
-    { label: "이름을 지어준 사람", placeholder: '내 이름은 누가 지어줬나요?' },
-    { label: "내가 좋아하는 나의 별명", placeholder: '내 별명은 무엇인가요?' },
-    { label: "별명을 지어준 사람", placeholder: '내 별명은 누가 지어줬나요?' }
+    { key: 'name', label: "나의 이름은?", placeholder: '이름이 무엇인가요?' },
+    { key: 'nameMeaning', label: "이름이 가진 의미", placeholder: '내 이름의 의미는 무엇인가요?' },
+    { key: 'nameGiver', label: "이름을 지어준 사람", placeholder: '내 이름은 누가 지어줬나요?' },
+    { key: 'nickname', label: "내가 좋아하는 나의 별명", placeholder: '내 별명은 무엇인가요?' },
+    { key: 'nicknameGiver', label: "별명을 지어준 사람", placeholder: '내 별명은 누가 지어줬나요?' }
 ];
 
-export function NameForm() {
-    return <FormList fields={nameFields} />;
+interface NameFormProps {
+    data: NameData;
+    onChange: (data: NameData) => void;
+}
+
+export function NameForm({ data, onChange }: NameFormProps) {
+    const handleChange = (key: string, value: string) => {
+        onChange({ ...data, [key]: value });
+    };
+
+    return (
+        <FormList
+            fields={nameFields}
+            values={data}
+            onChange={handleChange}
+        />
+    );
 }

--- a/src/features/cardThema/time/ui/season-form.tsx
+++ b/src/features/cardThema/time/ui/season-form.tsx
@@ -1,9 +1,26 @@
+'use client';
+
 import { FormList } from "@/shared/ui/form-list";
 
 const tasteFields = [
-    { label : "보기에 없는 경우에는 계절마다 \n내가 즐겨먹던 것을 자유롭게 적어보세요!", placeholder: '자유롭게 적어주세요' },
+    { key: 'freeText', label : "보기에 없는 경우에는 계절마다 \n내가 즐겨먹던 것을 자유롭게 적어보세요!", placeholder: '자유롭게 적어주세요' },
 ];
 
-export function TasteForm() {
-    return <FormList fields={tasteFields} />;
+interface TasteFormProps {
+    data: { freeText: string };
+    onChange: (data: { freeText: string }) => void;
+}
+
+export function TasteForm({ data, onChange }: TasteFormProps) {
+    const handleChange = (key: string, value: string) => {
+        onChange({ ...data, [key]: value });
+    };
+
+    return (
+        <FormList
+            fields={tasteFields}
+            values={data}
+            onChange={handleChange}
+        />
+    );
 }

--- a/src/shared/ui/form-list.tsx
+++ b/src/shared/ui/form-list.tsx
@@ -5,21 +5,26 @@ import { InputBox } from "@/shared/ui/input-box";
 interface FormField {
     label: string;
     placeholder: string;
+    key: string;
 }
 
 interface FormListProps {
     fields: FormField[];
+    values: Record<string, string>;
+    onChange: (key: string, value: string) => void;
     className?: string;
 }
 
-export function FormList({ fields, className = '' }: FormListProps) {
+export function FormList({ fields, values, onChange, className = '' }: FormListProps) {
     return (
         <div className={`flex-1 flex flex-col gap-6 rounded-[20px] px-6 py-10 bg-[#F6F6F6] ${className}`}>
-            {fields.map((field, index) => (
-                <div key={index} className="flex flex-col gap-2">
+            {fields.map((field) => (
+                <div key={field.key} className="flex flex-col gap-2">
                     <label className="text-sm font-medium text-gray-700">{field.label}</label>
                     <InputBox
                         placeholder={field.placeholder}
+                        value={values[field.key] || ''}
+                        onChange={(e) => onChange(field.key, e.target.value)}
                         className="bg-white py-3 rounded-[12px]"
                     />
                 </div>


### PR DESCRIPTION
# ⭐️ Issue Number  
> 해당되는 이슈 번호가 없다면 "None"이라고 작성해주세요.  

- #ISSUE_ID


# 🧑‍💻Assignees
> 이 작업에 참여한 사람을 기록해주세요.

- @Minter-v1 
  
# 📢 Description  
> 구현/수정한 내용을 간결하게 bullet 형식으로 작성해주세요.

- Me 테마 카드 API 연동 (cd-001 ~ cd-005)
- QR 코드 스캔 → 카드 UUID 조회 → 활동 저장 플로우 구현
- useCardFormSubmit 커스텀 훅으로 폼 저장 로직 통합
- 백엔드 Upsert 방식 적용 (동일 카드 재저장 시 수정 처리)
- 사용자의 모든 활동 기록을 3D 카드 스택 캐러셀로 표시
- 카드 플립 애니메이션으로 활동 내용 확인
- 터치 스와이프 지원
- 백엔드 필드명(tomorrowFood) → 한글 라벨(내일 먹을 음식) 변환
- 인덱스 값 → 실제 선택지 텍스트 변환 (예: 0 → 🔥 불 (열정적, 급함))


# 🛠️ Technical Concerns  
> 리뷰어나 팀원이 주의 깊게 봐야 할 기술적 포인트를 작성해주세요.

- 터치 스와이프는 모바일 테스트 하지 않았음. 안될 수도 있음


# 🙂 To Reviewer  
> 리뷰어가 여러 명이라면 확인 후 체크 표시를 남겨주세요.

- [ ] @swtae0214 



# 📌 Follow-Up Task  
> 이후에 이어서 진행할 작업을 자유롭게 정리해주세요.

- 나머지 공간, 시간 테마도 api 연결